### PR TITLE
Fixes the NullPointerException

### DIFF
--- a/AnCasino/src/me/darazo/ancasino/slot/RewardData.java
+++ b/AnCasino/src/me/darazo/ancasino/slot/RewardData.java
@@ -22,15 +22,15 @@ public class RewardData {
 		
 		if(reward.message != null) {
 			plugin.sendMessage(player, reward.message);
-		}
+		}else return;
 		
 		if(reward.money != null) {
 			plugin.economy.depositPlayer(player.getName(), reward.money);
-		}
+		}else return;
 		
 		if(reward.action != null && !reward.action.isEmpty()) {
 			executeAction(reward.action, player);
-		}
+		}else return;
 	}
 		
 	// Parses reward actions


### PR DESCRIPTION
I believe for configs that don't provide a reward message, or reward money, or reward action for it.

"2012-02-18 00:22:46 [WARNING] Task of 'AnCasino' generated an exception
java.lang.NullPointerException
    at me.darazo.ancasino.slot.RewardData.send(RewardData.java:23)
    at me.darazo.ancasino.slot.game.ResultsTask.run(ResultsTask.java:40)
    at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:137)
    at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:503)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:435)
    at net.minecraft.server.ThreadServerApplication.run(SourceFile:465)
"
